### PR TITLE
This project requires termbox-go.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ browser's network inspector with the "copy as cURL" feature.
 ## Installation and usage
 
 ```
+$ go get -u github.com/nsf/termbox-go
 $ go get github.com/asciimoo/wuzz
 $ "$GOPATH/bin/wuzz" --help
 ```


### PR DESCRIPTION
If you have not previously installed termbox-go you will get an error when you attempt to install the project.

```
$ go get github.com/asciimoo/wuzz
# github.com/jroimartin/gocui
../../.gocode/src/github.com/jroimartin/gocui/keybinding.go:74: undefined: termbox.MouseRelease
```

Informing the user they need termbox-go would be helpful so I have included it in the readme.