### PR TITLE
Add configuration system

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/mitchellh/go-homedir"
+)
+
+// Duration is used to automatically unmarshal timeout strings to
+// time.Duration values
+type Duration struct {
+	time.Duration
+}
+
+func (d *Duration) UnmarshalText(text []byte) error {
+	var err error
+	d.Duration, err = time.ParseDuration(string(text))
+	return err
+}
+
+type Config struct {
+	General GeneralOptions
+	Keys    map[string]map[string]string
+}
+
+type GeneralOptions struct {
+	Timeout                Duration
+	FormatJSON             bool
+	PreserveScrollPosition bool
+	DefaultURLScheme       string
+}
+
+var defaultTimeoutDuration, _ = time.ParseDuration("1m")
+
+var DefaultConfig = Config{
+	General: GeneralOptions{
+		Timeout: Duration{
+			defaultTimeoutDuration,
+		},
+		FormatJSON:             true,
+		PreserveScrollPosition: true,
+		DefaultURLScheme:       "https",
+	},
+}
+
+func LoadConfig(configFile string) (*Config, error) {
+	if _, err := os.Stat(configFile); os.IsNotExist(err) {
+		return nil, errors.New("Config file does not exist.")
+	} else if err != nil {
+		return nil, err
+	}
+
+	conf := DefaultConfig
+	if _, err := toml.DecodeFile(configFile, &conf); err != nil {
+		return nil, err
+	}
+
+	return &conf, nil
+}
+
+func GetDefaultConfigLocation() string {
+	var configFolderLocation string
+	switch runtime.GOOS {
+	case "linux":
+		// Use the XDG_CONFIG_HOME variable if it is set, otherwise
+		// $HOME/.config/wuzz/config.toml
+		xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
+		if xdgConfigHome != "" {
+			configFolderLocation = xdgConfigHome
+		} else {
+			configFolderLocation, _ = homedir.Expand("~/.config/wuzz/")
+		}
+
+	default:
+		// On other platforms we just use $HOME/.wuzz
+		configFolderLocation, _ = homedir.Expand("~/.wuzz/")
+	}
+
+	return filepath.Join(configFolderLocation, "config.toml")
+}

--- a/sample-config.toml
+++ b/sample-config.toml
@@ -1,0 +1,6 @@
+[general]
+
+timeout = "1m"
+defaultURLScheme = "https"
+formatJSON = true
+preserveScrollPosition = true


### PR DESCRIPTION
The new configuration system, using TOML, loads into `app.config` using a TOML config file. This can be specified on the command-line with the `-c` option, or it can be at one of the following default locations:

- Linux: $XDG_CONFIG_HOME/wuzz/config.toml (by default this is ~/.config/wuzz/config.toml)
- Other OSs: ~/.wuzz/config.toml

Currently the following keys can be set, along with their default values:

```toml
[general]

timeout = "1m" # string parsed into time.Duration
formatJSON = true # toggles JSON formatting
preserveScrollPosition = true # currently unused
defaultURLScheme = "https" # when a URL is not provided, this is the scheme used by default
```

In addition, a `[keys]` section can also be set and will be successfully parsed, but it is currently non-functional.