### PR TITLE
use gocui.Ascii for CJK

### DIFF
--- a/wuzz.go
+++ b/wuzz.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/jroimartin/gocui"
+	"github.com/mattn/go-runewidth"
 )
 
 const VERSION = "0.1.0"
@@ -1007,6 +1008,9 @@ func main() {
 	g, err := gocui.NewGui(gocui.Output256)
 	if err != nil {
 		log.Panicln(err)
+	}
+	if runtime.GOOS == "windows" && runewidth.IsEastAsian() {
+		g.Ascii = true
 	}
 
 	app := &App{history: make([]*Request, 0, 31)}


### PR DESCRIPTION
In CJK, border characters are double width on Windows cmd.exe

![before](http://go-gyazo.appspot.com/090dc2890118112f.png)

Now gocui add new option to use ASCII.

https://github.com/jroimartin/gocui/pull/93

This is a patch to use ASCII when wuzz run on Windows in CJK.

![after](http://go-gyazo.appspot.com/eb24c47f44169bd8.png)