### PR TITLE
#49 - Ignore Invalid SSL Cert

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 type GeneralOptions struct {
 	Timeout                Duration
 	FormatJSON             bool
+	Insecure               bool
 	PreserveScrollPosition bool
 	DefaultURLScheme       string
 }
@@ -43,6 +44,7 @@ var DefaultConfig = Config{
 			defaultTimeoutDuration,
 		},
 		FormatJSON:             true,
+		Insecure:               false,
 		PreserveScrollPosition: true,
 		DefaultURLScheme:       "https",
 	},

--- a/sample-config.toml
+++ b/sample-config.toml
@@ -4,3 +4,4 @@ timeout = "1m"
 defaultURLScheme = "https"
 formatJSON = true
 preserveScrollPosition = true
+insecure = false

--- a/wuzz.go
+++ b/wuzz.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/asciimoo/wuzz/config"
 
+	"crypto/tls"
 	"github.com/jroimartin/gocui"
 	"github.com/mattn/go-runewidth"
-	"crypto/tls"
 )
 
 const VERSION = "0.1.0"

--- a/wuzz.go
+++ b/wuzz.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/jroimartin/gocui"
 	"github.com/mattn/go-runewidth"
+	"crypto/tls"
 )
 
 const VERSION = "0.1.0"
@@ -920,6 +921,8 @@ func (a *App) ParseArgs(g *gocui.Gui, args []string) error {
 			if strings.Index(getViewValue(g, "headers"), "Accept-Encoding") == -1 {
 				fmt.Fprintln(vh, "Accept-Encoding: gzip, deflate")
 			}
+		case "--insecure":
+			a.config.General.Insecure = true
 		default:
 			u := args[arg_index]
 			if strings.Index(u, "http://") != 0 && strings.Index(u, "https://") != 0 {
@@ -952,6 +955,7 @@ func (a *App) ParseArgs(g *gocui.Gui, args []string) error {
 // args can override the provided config values
 func (a *App) InitConfig() {
 	CLIENT.Timeout = a.config.General.Timeout.Duration
+	TRANSPORT.TLSClientConfig = &tls.Config{InsecureSkipVerify: a.config.General.Insecure}
 }
 
 func initApp(a *App, g *gocui.Gui) {


### PR DESCRIPTION
This is another pull request to add functionality for websites with invalid ssl certificates. I messed up the git history on the previous one and I think I closed the pull request in the process of fixing it. I'm hoping this has got everything fixed, but please let me know if there is anything else I need to change.