### PR TITLE
#65 - Save Requests

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -14,8 +14,11 @@ var COMMANDS map[string]func(string, *App) CommandFunc = map[string]func(string,
 	"submit": func(_ string, a *App) CommandFunc {
 		return a.SubmitRequest
 	},
-	"save": func(_ string, a *App) CommandFunc {
-		return a.OpenSaveDialog
+	"saveResponse": func(_ string, a *App) CommandFunc {
+		return a.OpenSaveResponseDialog
+	},
+	"saveRequest": func(_ string, a *App) CommandFunc {
+		return a.OpenSaveRequestDialog
 	},
 	"history": func(_ string, a *App) CommandFunc {
 		return a.ToggleHistory

--- a/config/config.go
+++ b/config/config.go
@@ -51,7 +51,8 @@ var DefaultKeys = map[string]map[string]string{
 	"global": map[string]string{
 		"CtrlR": "submit",
 		"CtrlC": "quit",
-		"CtrlS": "save",
+		"CtrlS": "saveResponse",
+		"CtrlE": "saveRequest",
 		"CtrlD": "deleteLine",
 		"CtrlW": "deleteWord",
 		"Tab":   "nextView",

--- a/wuzz.go
+++ b/wuzz.go
@@ -1117,6 +1117,11 @@ func (a *App) SetKeys(g *gocui.Gui) error {
 		return nil
 	})
 
+	g.SetKeybinding(SAVE_REQUEST_DIALOG_VIEW, gocui.KeyCtrlQ, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
+		a.closePopup(g, SAVE_REQUEST_DIALOG_VIEW)
+		return nil
+	})
+
 	g.SetKeybinding(SAVE_RESULT_VIEW, gocui.KeyEnter, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
 		a.closePopup(g, SAVE_RESULT_VIEW)
 		return nil

--- a/wuzz.go
+++ b/wuzz.go
@@ -1088,11 +1088,11 @@ func (a *App) SetKeys(g *gocui.Gui) error {
 
 		var requestMap map[string]string
 		requestMap = make(map[string]string)
-		requestMap["url"] = getViewValue(g, URL_VIEW)
-		requestMap["method"] = getViewValue(g, REQUEST_METHOD_VIEW)
-		requestMap["params"] = getViewValue(g, URL_PARAMS_VIEW)
-		requestMap["data"] = getViewValue(g, REQUEST_DATA_VIEW)
-		requestMap["headers"] = getViewValue(g, REQUEST_HEADERS_VIEW)
+		requestMap[URL_VIEW] = getViewValue(g, URL_VIEW)
+		requestMap[REQUEST_METHOD_VIEW] = getViewValue(g, REQUEST_METHOD_VIEW)
+		requestMap[URL_PARAMS_VIEW] = getViewValue(g, URL_PARAMS_VIEW)
+		requestMap[REQUEST_DATA_VIEW] = getViewValue(g, REQUEST_DATA_VIEW)
+		requestMap[REQUEST_HEADERS_VIEW] = getViewValue(g, REQUEST_HEADERS_VIEW)
 
 		requestJson, err := json.Marshal(requestMap)
 		if err != nil {
@@ -1501,31 +1501,31 @@ func (a *App) ParseArgs(g *gocui.Gui, args []string) error {
 			}
 
 			var v *gocui.View
-			url, exists := requestMap["url"]
+			url, exists := requestMap[URL_VIEW]
 			if exists {
 				v, _ = g.View(URL_VIEW)
 				setViewTextAndCursor(v, url)
 			}
 
-			method, exists := requestMap["method"]
+			method, exists := requestMap[REQUEST_METHOD_VIEW]
 			if exists {
 				v, _ = g.View(REQUEST_METHOD_VIEW)
 				setViewTextAndCursor(v, method)
 			}
 
-			params, exists := requestMap["params"]
+			params, exists := requestMap[URL_PARAMS_VIEW]
 			if exists {
 				v, _ = g.View(URL_PARAMS_VIEW)
 				setViewTextAndCursor(v, params)
 			}
 
-			data, exists := requestMap["data"]
+			data, exists := requestMap[REQUEST_DATA_VIEW]
 			if exists {
 				v, _ = g.View(REQUEST_DATA_VIEW)
 				setViewTextAndCursor(v, data)
 			}
 
-			headers, exists := requestMap["headers"]
+			headers, exists := requestMap[REQUEST_HEADERS_VIEW]
 			if exists {
 				v, _ = g.View(REQUEST_HEADERS_VIEW)
 				setViewTextAndCursor(v, headers)


### PR DESCRIPTION
I have implemented functionality that allows for requests to be saved as a json file. To do this create a request and press `CTRL-e` This opens the save request dialog which functions identically to the save response dialog. After a request has been saved start wuzz with `wuzz -f /path/to/request.json` and the application starts with all of the request fields initialized. There were a couple of things I wanted to get some feedback on though:
- Is there a better key than `CTRL-e`? All of the ones that to me seemed like they would make since for this functionality are already taken.
- Should we include an additional command line flag that indicates that you want the request run automatically? Or maybe instead the -f command would do this? My only issue with -f automatically invoking the request is I could see this functionality being used to create "request templates" where most of the information is pre-populated, but a few parameters are provided after opening wuzz, but before running the request. Not that this would cause problems, but I could see it being an inconvenience.