### PR TITLE
Fix `Host` header not being sent

### DIFF
--- a/wuzz.go
+++ b/wuzz.go
@@ -819,6 +819,11 @@ func (a *App) SubmitRequest(g *gocui.Gui, _ *gocui.View) error {
 		}
 		req.Header = headers
 
+		// set the `Host` header
+		if headers.Get("Host") != "" {
+			req.Host = headers.Get("Host")
+		}
+
 		// do request
 		start := time.Now()
 		response, err := CLIENT.Do(req)


### PR DESCRIPTION
See: https://github.com/golang/go/issues/7682

Custom headers are set using `headers.Set(..)`.
When it comes to the `Host` header however, this will have no impact
because the request uses the `Host` field from `Request`. If it is
not set, then `URL.Host` will be used.

This commit will make `wuzz` behaviour consistent with cURL.

---

A simple test:

1. Run `curl -i -X GET --url https://httpbin.org/get --header 'Host: fyianlai.com'`
2. Now run `wuzz -k curl -i -X GET --url https://httpbin.org/get --header 'Host: fyianlai.com'`

In (2), you should notice that the `Host` header is not correctly set.