### PR TITLE
fix: handling of multiple same-name query params

### DIFF
--- a/wuzz.go
+++ b/wuzz.go
@@ -732,7 +732,9 @@ func (a *App) SubmitRequest(g *gocui.Gui, _ *gocui.View) error {
 		}
 		originalQuery := u.Query()
 		for k, v := range q {
-			originalQuery.Add(k, strings.Join(v, ""))
+			for _, qp := range v {
+				originalQuery.Add(k, qp)
+			}
 		}
 		u.RawQuery = originalQuery.Encode()
 		r.GetParams = u.RawQuery
@@ -1587,7 +1589,9 @@ func (a *App) ParseArgs(g *gocui.Gui, args []string) error {
 			vurl, _ := g.View(URL_VIEW)
 			vurl.Clear()
 			for k, v := range parsed_url.Query() {
-				fmt.Fprintf(vget, "%v=%v\n", k, strings.Join(v, ""))
+				for _, vv := range v {
+					fmt.Fprintf(vget, "%v=%v\n", k, vv)
+				}
 			}
 			parsed_url.RawQuery = ""
 			setViewTextAndCursor(vurl, parsed_url.String())


### PR DESCRIPTION
Multiple get parameters with the same name are now printed each in their
own line. The parameters get added to the query string correctly, each
one as a single param.

You can verify the misbehavior by entering sthg along the lines:

```sh

./wuzz 'https://some-url.com?filter=1&uuid=ba8ff440-823d-11e4-843e-be5cc84539f9&uuid=31d587e1-2df0-11e4-b57e-1ef9c74539f9'

```

this will concatenate the two uuids as one string in the upstream version and is fixed by this pull request.