### PR TITLE
Print trailers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.7.5
-  - 1.8.3
+  - 1.10.x
+  - tip
 os:
   - linux
   # remove osx, getting vm from travis is extremely slow

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ go get github.com/asciimoo/wuzz
 $ "$GOPATH/bin/wuzz" --help
 ```
 
-Note: golang >= 1.7 required.
+Note: golang >= 1.10 required.
 
 [Binary releases](https://github.com/asciimoo/wuzz/releases) are also available.
 


### PR DESCRIPTION
Hey @andradei, I took a stab at fixing #100 (Support for Trailers).

This PR consists of 3 changes:
- the actual implementation
- small refactor to use `strings.Builder` instead of string concatenation for efficiency
- `strings.Builder` is not available before Go 1.10, so I bumped up the minimum required Go version too. If you're not OK with this, I can leave the refactor for a future PR.

For the sample HTTP server in the reported issue, the output now looks like this:
```
─Response headers──────────────────────
HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
Date: Wed, 03 Oct 2018 14:07:27 GMT
Atend1: value 1
Atend2: value 2
Atend3: value 3
```