### PR TITLE
Add snapcraft.yaml to enable snap builds.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,27 @@
+name: wuzz
+summary: Interactive cli tool for HTTP inspection
+description: |
+  Wuzz command line arguments are similar to cURL's arguments, so it can be
+  used to inspect/modify requests copied from the browser's network inspector
+  with the "copy as cURL" feature.
+adopt-info: wuzz
+confinement: strict
+
+apps:
+    wuzz:
+        command: bin/wuzz
+        plugs: [ network ]
+parts:
+    wuzz:
+        source: .
+        plugin: go
+        go-importpath: github.com/asciimoo/wuzz
+        override-pull: |
+            snapcraftctl pull
+            version="$(git describe --always | sed -e 's/-/+git/;y/-/./')"
+            [ -n "$(echo $version | grep "+git")" ] && grade=devel || grade=stable
+            snapcraftctl set-version "$version"
+            snapcraftctl set-grade "$grade"
+        after: [go]
+    go:
+        source-tag: go1.10.5


### PR DESCRIPTION
Hi

This PR adds support for building a snap package of wuzz. Snaps are cross distro Linux software packages. One snap can be installed on Ubuntu all supported LTS and non LTS releases from 14.04 onward. Additionally they can installed on Debian, Manjaro, Fedora, OpenSUSE and others. Making a snap of wuzz enables you to provide automatic updates on your schedule to your users via the snap store.

If accepted, you can use snapcraft locally, a CI system such as travis or circle-ci, or our free build system (build.snapcraft.io) to create snaps and upload to the store (snapcraft.io/store).

To test this PR locally, I used an Ubuntu 16.04 VM, with the following steps.

    snap install snapcraft --classic
    git clone -b snapcraft https://github.com/dargad/wuzz
    cd wuzz
    snapcraft

Please note that snapcraft.yaml has been implemented in such a way it automatically picks up wuzz version from a tag. It can be installed with:

    snap install --dangerous wuzz_amd64.snap

(the --dangerous is necessary because we’re installing an app which hasn’t gone through the snap store review process)

Once installed the command can be executed: `wuzz`
![screenshot from 2018-12-07 10-21-17](https://user-images.githubusercontent.com/468720/49638970-0b3d8c00-fa0a-11e8-9347-291124cc3b30.png)

If landed, you will need to:
* Register an account in the snap store https://snapcraft.io/account
* Register the 'wuzz' name in the store. *Please note the name is already taken and it is offering your project, but since you are the official upstream maybe there's something we can figure out - please get in touch with us to solve that.*
```
snapcraft login
snapcraft register wuzz
```

* Upload a built snap to the store
```snapcraft push wuzz_amd64.snap --release edge```
* Test installing on a clean Ubuntu 16.04 machine:
```snap install wuzz --edge```

The store supports multiple risk levels as “channels” with the edge channel typically used to host the latest build from git master. Stable is where stable releases are pushed. Optionally beta and candidate channels can also be used if needed.

Once you are happy, you can push a stable release to the stable channel, update the store page, and promote the application online (we can help there).