### PR TITLE
Redirect restricted mode shortcut toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Keybinding                              | Description
 <kbd>F7</kbd>                           | Jump to search
 <kbd>F8</kbd>                           | Jump to response headers
 <kbd>F9</kbd>                           | Jump to response body
+<kbd>F12</kbd>                          | Redirects Restriction Mode
 
 
 ### Context specific search

--- a/config/config.go
+++ b/config/config.go
@@ -74,6 +74,7 @@ var DefaultKeys = map[string]map[string]string{
 		"F7":    "focus search",
 		"F8":    "focus response-headers",
 		"F9":    "focus response-body",
+		"F12":   "redirects restriction mode",
 	},
 	"url": {
 		"Enter": "submit",

--- a/config/config.go
+++ b/config/config.go
@@ -106,7 +106,7 @@ var DefaultConfig = Config{
 		FormatJSON:             true,
 		Insecure:               false,
 		PreserveScrollPosition: true,
-		StatusLine:             "[wuzz {{.Version}}]{{if .Duration}} [Response time: {{.Duration}}]{{end}} [Request no.: {{.RequestNumber}}/{{.HistorySize}}] [Search type: {{.SearchType}}]",
+		StatusLine:             "[wuzz {{.Version}}]{{if .Duration}} [Response time: {{.Duration}}]{{end}} [Request no.: {{.RequestNumber}}/{{.HistorySize}}] [Search type: {{.SearchType}}]{{if .DisableRedirect}} [Redirects Restricted Mode {{.DisableRedirect}}]{{end}}",
 		Timeout: Duration{
 			defaultTimeoutDuration,
 		},

--- a/sample-config.toml
+++ b/sample-config.toml
@@ -31,6 +31,7 @@ F6 = "focus headers"
 F7 = "focus search"
 F8 = "focus response-headers"
 F9 = "focus response-body"
+F12 = "redirects restriction mode"
 
 [keys.url]
 Enter = "submit"

--- a/status-line.go
+++ b/status-line.go
@@ -57,6 +57,13 @@ func (s *StatusLine) Update(v *gocui.View, a *App) {
 	}
 }
 
+func (s *StatusLineFunctions) DisableRedirect() string {
+	if s.app.config.General.FollowRedirects {
+		return ""
+	}
+	return "Actived"
+}
+
 func NewStatusLine(format string) (*StatusLine, error) {
 	tpl, err := template.New("status line").Parse(format)
 	if err != nil {


### PR DESCRIPTION
Hi @wngmnheiko 
I made the shortcut that you requested on issue #89 
What I changed:
- Status Line on the button, shows the toggle of the mode is activated or not, when the redirects restriction isn't active, it won't show on status line
- using F12 as the shortcut to activate or deactivate the `redirects restriction`

here is the screenshot:
![Screenshot from 2019-10-03 22-43-46](https://user-images.githubusercontent.com/47969743/66147038-2d0e9c00-e638-11e9-98a9-fb7a75fee3b5.png)
