### PR TITLE
rename remaining instances of F12 to F11

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Keybinding                              | Description
 <kbd>F7</kbd>                           | Jump to search
 <kbd>F8</kbd>                           | Jump to response headers
 <kbd>F9</kbd>                           | Jump to response body
-<kbd>F12</kbd>                          | Redirects Restriction Mode
+<kbd>F11</kbd>                          | Redirects Restriction Mode
 
 
 ### Context specific search

--- a/sample-config.toml
+++ b/sample-config.toml
@@ -31,7 +31,7 @@ F6 = "focus headers"
 F7 = "focus search"
 F8 = "focus response-headers"
 F9 = "focus response-body"
-F12 = "redirects restriction mode"
+F11 = "redirects restriction mode"
 
 [keys.url]
 Enter = "submit"

--- a/status-line.go
+++ b/status-line.go
@@ -61,7 +61,7 @@ func (s *StatusLineFunctions) DisableRedirect() string {
 	if s.app.config.General.FollowRedirects {
 		return ""
 	}
-	return "Actived"
+	return "Activated"
 }
 
 func NewStatusLine(format string) (*StatusLine, error) {

--- a/wuzz.go
+++ b/wuzz.go
@@ -1096,7 +1096,7 @@ func (a *App) SetKeys(g *gocui.Gui) error {
 		return nil
 	})
 
-	g.SetKeybinding(ALL_VIEWS, gocui.KeyF12, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
+	g.SetKeybinding(ALL_VIEWS, gocui.KeyF11, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
 		a.config.General.FollowRedirects = !a.config.General.FollowRedirects
 		refreshStatusLine(a, g)
 		return nil


### PR DESCRIPTION
Looks like a few places were missed in the last commit. Also fixed a typo.