### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+**
+
+!config
+!formatter
+!*.go
+!go.mod
+!sample-config.toml
+!docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM alpine:3.12 AS permissions-giver
+
+# Make sure docker-entrypoint.sh is executable, regardless of the build host.
+WORKDIR /out
+COPY docker-entrypoint.sh .
+RUN chmod +x docker-entrypoint.sh
+
+FROM golang:1.14-alpine3.12 AS builder
+
+# Build wuzz
+WORKDIR /out
+COPY . .
+RUN go build .
+
+FROM alpine:3.12 AS organizer
+
+# Prepare executables
+WORKDIR /out
+COPY --from=builder /out/wuzz .
+COPY --from=permissions-giver /out/docker-entrypoint.sh .
+
+FROM alpine:3.12 AS runner
+WORKDIR /wuzz
+COPY --from=organizer /out /usr/local/bin
+ENTRYPOINT [ "docker-entrypoint.sh" ]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+if [ "${1#-}" != "${1}" ] || [ -z "$(command -v "${1}")" ]; then
+  sleep 0.01
+  set -- wuzz "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Added a Dockerfile that builds a `wuzz` Docker image. This Dockerfile uses multi-stage builds and produces an image with a size of `17.2MB`.

## Build

`docker image build -t wuzz .`

## Run

`docker image run -it --rm wuzz`

One could "install" `wuzz` using the following:

`alias wuzz='docker image run -it --rm yardenshoham/wuzz'`

I published the image though it'll probably be better to [setup automated builds on Docker hub](https://docs.docker.com/docker-hub/builds/), @asciimoo thoughts?

Closes #11 

Related: https://github.com/asciimoo/wuzz/pull/11#issuecomment-663840992