### PR TITLE
Mac vim excess characters bug fix #137

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Keybinding                              | Description
 <kbd>Ctrl+C</kbd>                       | Quit
 <kbd>Ctrl+K</kbd>, <kbd>Shift+Tab</kbd> | Previous view
 <kbd>Ctlr+J</kbd>, <kbd>Tab</kbd>       | Next view
+<kbd>Ctrl+O</kbd>                       | Open view in text editor
 <kbd>Ctlr+T</kbd>                       | Toggle context specific search
 <kbd>Alt+H</kbd>                        | Toggle history
 <kbd>Down</kbd>                         | Move down one view line

--- a/commands.go
+++ b/commands.go
@@ -5,12 +5,15 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"unicode"
 
 	"github.com/jroimartin/gocui"
 	"github.com/nsf/termbox-go"
 )
+
+const MAC_OS = "darwin"
 
 type CommandFunc func(*gocui.Gui, *gocui.View) error
 
@@ -236,7 +239,13 @@ func openEditor(g *gocui.Gui, v *gocui.View, editor string) error {
 		return nil
 	}
 
-	cmd := exec.Command(editor, file.Name())
+	var cmd *exec.Cmd
+	// Some .vimrc files might not play nice. To play it safe, don't use them.
+	if editor == "vim" && runtime.GOOS == MAC_OS {
+		cmd = exec.Command(editor, "-u", "NONE", file.Name())
+	} else {
+		cmd = exec.Command(editor, file.Name())
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr

--- a/wuzz.go
+++ b/wuzz.go
@@ -1845,6 +1845,9 @@ func main() {
 			fmt.Printf("wuzz %v\n", VERSION)
 			return
 		case "-c", "--config":
+			if i+1 >= len(os.Args) {
+				log.Fatal("Expected file after -c")
+			}
 			configPath = os.Args[i+1]
 			args = append(os.Args[:i], os.Args[i+2:]...)
 			if _, err := os.Stat(configPath); os.IsNotExist(err) {


### PR DESCRIPTION
Potential fix for issue #137 with random chars from vim on mac, helpful failure for -c without a file, added CTRL+O to README

I saw the same error on a similar Mac. I experimented a bit and I don't think this is related to the gocui library. Seems to have something to do with .vimrc settings causing vim to spit out weird data into stdout after shutdown: 
https://stackoverflow.com/questions/51129631/vim-8-1-garbage-printing-on-screen

Tough to ensure users have a good .vimrc, but one solution is to just not use the .vimrc if the editor is set to vim on a mac: 


`	var cmd *exec.Cmd
	if editor == "vim" && runtime.GOOS == MAC_OS {
		cmd = exec.Command(editor, "-u", "NONE", file.Name())
	} else {
		cmd = exec.Command(editor, file.Name())
	}
`

Not ideal but works. I also added a helpful failure message for running the -c flag and no file, rather than a seg fault. 