### PR TITLE
`go get` -> `go install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ browser's network inspector with the "copy as cURL" feature.
 ## Installation and usage
 
 ```
-$ go get github.com/asciimoo/wuzz
+$ go install github.com/asciimoo/wuzz
 $ "$GOPATH/bin/wuzz" --help
 ```
 


### PR DESCRIPTION
Since the functionality of `go get` was moved to `go install`, running the `go get` command in README.md won't build and install wuzz, like it used to.