### PR TITLE
fix(sec): upgrade github.com/tidwall/gjson to 1.9.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nsf/termbox-go v0.0.0-20200418040025-38ba6e5628f1
 	github.com/nwidger/jsoncolor v0.3.0
-	github.com/tidwall/gjson v1.6.0
-	github.com/tidwall/pretty v1.0.1 // indirect
+	github.com/tidwall/gjson v1.9.3
 	github.com/x86kernel/htmlcolor v0.0.0-20190529101448-c589f58466d0
 	golang.org/x/net v0.0.0-20200602114024-627f9648deb9
 	golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 // indirect


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in github.com/tidwall/gjson v1.6.0
- [CVE-2020-36066](https://www.oscs1024.com/hd/CVE-2020-36066)


### What did I do？
Upgrade github.com/tidwall/gjson from v1.6.0 to 1.9.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS