### PR TITLE
Fix panic on trailing -c/--config flag

### DIFF
--- a/wuzz.go
+++ b/wuzz.go
@@ -1866,6 +1866,9 @@ func main() {
 			fmt.Printf("wuzz %v\n", VERSION)
 			return
 		case "-c", "--config":
+			if i == len(os.Args)-1 {
+				log.Fatal("No config file specified after -c/--config")
+			}
 			configPath = os.Args[i+1]
 			args = append(os.Args[:i], os.Args[i+2:]...)
 			if _, err := os.Stat(configPath); os.IsNotExist(err) {


### PR DESCRIPTION
Fixes #161

`main()` read `os.Args[i+1]` for the `-c`/`--config` flag without a bounds check, unlike the other value flags. Running `wuzz -c` with no following argument panicked with an index-out-of-range error.

This adds a bounds check that fails with a clear fatal message instead.

Verified by building the binary: `wuzz -c` now exits with `No config file specified after -c/--config` (exit 1) rather than panicking.