### PR TITLE
Fix unparseable multipart/form-data uploads

### DIFF
--- a/wuzz.go
+++ b/wuzz.go
@@ -802,7 +802,6 @@ func (a *App) SubmitRequest(g *gocui.Gui, _ *gocui.View) error {
 			} else {
 				var bodyBytes bytes.Buffer
 				multiWriter := multipart.NewWriter(&bodyBytes)
-				defer multiWriter.Close()
 				postData, err := url.ParseQuery(strings.Replace(getViewValue(g, REQUEST_DATA_VIEW), "\n", "&", -1))
 				if err != nil {
 					return err
@@ -838,6 +837,10 @@ func (a *App) SubmitRequest(g *gocui.Gui, _ *gocui.View) error {
 						}
 					}
 				}
+				if err := multiWriter.Close(); err != nil {
+					return err
+				}
+				headers.Set("Content-Type", multiWriter.FormDataContentType())
 				body = bytes.NewReader(bodyBytes.Bytes())
 			}
 		}


### PR DESCRIPTION
Fixes #163

Two problems made every multipart upload body rejected by servers with `no multipart boundary param in Content-Type` and truncated:

- The `Content-Type` header was sent as the literal `multipart/form-data` with no boundary parameter.
- `multiWriter.Close()` ran via `defer`, after the body buffer was already captured and sent, so the terminating boundary was missing.

This closes the writer before capturing the buffer and sets `Content-Type` to `multiWriter.FormDataContentType()`, which includes the boundary.

Verified by replicating the multipart construction against an `httptest` server using `req.ParseMultipartForm`: the current code fails with the boundary error, the fixed code parses cleanly.