### PR TITLE
Fix LoadConfig aliasing the shared DefaultKeys map

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -146,7 +146,14 @@ func LoadConfig(configFile string) (*Config, error) {
 					}
 				}
 			} else {
-				conf.Keys[keyCategory] = keys
+				// copy the category map instead of aliasing the
+				// shared DefaultKeys map, otherwise mutating this
+				// config would corrupt the global defaults.
+				categoryCopy := make(map[string]string, len(keys))
+				for key, action := range keys {
+					categoryCopy[key] = action
+				}
+				conf.Keys[keyCategory] = categoryCopy
 			}
 		}
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadConfigDoesNotAliasDefaultKeys ensures that when a config file
+// provides a Keys table but omits a category, the omitted category in the
+// returned config is a copy of the default, not a reference to the shared
+// DefaultKeys map. Otherwise mutating one loaded config corrupts the
+// global defaults seen by every subsequent LoadConfig call.
+func TestLoadConfigDoesNotAliasDefaultKeys(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+
+	// A config that defines Keys but omits the "url" category.
+	contents := "" +
+		"[keys.global]\n" +
+		"CtrlR = \"submit\"\n"
+	if err := os.WriteFile(cfgPath, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	originalURLSubmit := DefaultKeys["url"]["Enter"]
+
+	conf, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The omitted "url" category must be present (copied from defaults).
+	if got := conf.Keys["url"]["Enter"]; got != originalURLSubmit {
+		t.Fatalf("expected url.Enter %q, got %q", originalURLSubmit, got)
+	}
+
+	// Mutating the returned config's "url" category must not leak into the
+	// shared DefaultKeys map.
+	conf.Keys["url"]["Enter"] = "mutated"
+
+	if DefaultKeys["url"]["Enter"] != originalURLSubmit {
+		t.Fatalf("DefaultKeys was mutated via the loaded config: url.Enter = %q, expected %q",
+			DefaultKeys["url"]["Enter"], originalURLSubmit)
+	}
+}


### PR DESCRIPTION
Fixes #165

When a config file defined a `[keys]` table but omitted a category, `LoadConfig` assigned the shared `DefaultKeys` category map by reference. Mutating the returned config then corrupted the global defaults seen by subsequent `LoadConfig` calls.

This copies the category map instead, matching how present categories are already handled.

Includes a regression test that fails before the fix (the loaded config mutation leaks into `DefaultKeys`) and passes after.