### PR TITLE
Append duplicate request headers instead of dropping them

### DIFF
--- a/wuzz.go
+++ b/wuzz.go
@@ -784,7 +784,11 @@ func (a *App) SubmitRequest(g *gocui.Gui, _ *gocui.View) error {
 					})
 					return nil
 				}
-				headers.Set(header_parts[0], header_parts[1])
+				if http.CanonicalHeaderKey(header_parts[0]) == "User-Agent" {
+					headers.Set(header_parts[0], header_parts[1])
+				} else {
+					headers.Add(header_parts[0], header_parts[1])
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes #167.

## Problem
When the request headers editor has multiple lines with the same header name, wuzz sent only the **last** value and silently dropped the rest. This happens often when replaying a copied cURL with repeated `-H` flags (e.g. multiple `X-Custom:` or `Cookie:` lines). cURL sends all of them; wuzz diverged and discarded data with no warning.

## Cause
In `SubmitRequest`, the per-line header loop used `headers.Set` (replace) instead of `headers.Add` (append):

```go
headers.Set(header_parts[0], header_parts[1])
```

## Fix
Use `headers.Add` for user-entered headers so repeated names are all sent. `User-Agent` keeps `Set` semantics so the empty default seeded before the loop (`headers.Set("User-Agent", "")`) is replaced rather than duplicated:

```go
if http.CanonicalHeaderKey(header_parts[0]) == "User-Agent" {
    headers.Set(header_parts[0], header_parts[1])
} else {
    headers.Add(header_parts[0], header_parts[1])
}
```

## Testing
`SubmitRequest` is coupled to gocui (it reads header text from a view), so the parsing loop isn't directly unit-testable without refactoring. I verified by replicating the exact loop against `net/http`'s `http.Header`:

- Input `X-Custom: one` + `X-Custom: two`: with the fix both values are present (`[one two]`); on master only `[two]`.
- Input two `User-Agent:` lines: stays single (no duplicate), last value wins.

`go build ./...` and `go vet ./...` are clean.