### PR TITLE
Avoid panic when -c/--config has no argument

### DIFF
--- a/wuzz.go
+++ b/wuzz.go
@@ -1866,6 +1866,9 @@ func main() {
 			fmt.Printf("wuzz %v\n", VERSION)
 			return
 		case "-c", "--config":
+			if i == len(os.Args)-1 {
+				log.Fatal("No config file specified")
+			}
 			configPath = os.Args[i+1]
 			args = append(os.Args[:i], os.Args[i+2:]...)
 			if _, err := os.Stat(configPath); os.IsNotExist(err) {


### PR DESCRIPTION
Running `wuzz -c` (or `--config`) with no following argument reads `os.Args[i+1]` past the end of the slice and panics with "index out of range". This adds a bounds check so it exits with "No config file specified" instead, matching how the other value flags in ParseArgs are handled. Fixes #161.